### PR TITLE
GP-40118: Add new condition when needs to set 'order_exported_date'

### DIFF
--- a/Civi/Webshoptools/HandleWebShopActivity.php
+++ b/Civi/Webshoptools/HandleWebShopActivity.php
@@ -218,6 +218,11 @@ class HandleWebShopActivity {
       return true;
     }
 
+    // TODO: Test all cases
+    if ($isSetNewValueOrderExported && $newValueOrderExported == '1' && (!$isSetNewValueOrderExportedDate || empty($customFieldsData['order_exported_date']['new_value']))) {
+      return true;
+    }
+
     if ($isSetNewValueOrderExported && $newValueOrderExported == '1' && $isSetNewValueOrderExportedDate) {
       return false;
     }

--- a/Civi/Webshoptools/HandleWebShopActivity.php
+++ b/Civi/Webshoptools/HandleWebShopActivity.php
@@ -191,7 +191,7 @@ class HandleWebShopActivity {
 
     if ($operation == 'edit') {
       $currentStatusId = (int) $currentActivity['status_id'];
-      $newStatusId = (int) $params['status_id'];
+      $newStatusId = (int) ($params['status_id'] ?? NULL);
       return $currentStatusId != $newStatusId && $newStatusId == $completedStatusId;
     }
 

--- a/tests/phpunit/CRM/Webshoptools/WebshoptoolsTest.php
+++ b/tests/phpunit/CRM/Webshoptools/WebshoptoolsTest.php
@@ -16,7 +16,7 @@ class CRM_Webshoptools_WebshoptoolsTest extends \PHPUnit\Framework\TestCase impl
   public function setUpHeadless() {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
-      ->apply();
+      ->apply(TRUE);
   }
 
   /**
@@ -45,6 +45,8 @@ class CRM_Webshoptools_WebshoptoolsTest extends \PHPUnit\Framework\TestCase impl
       'shirt_type' => ['data_type' => 'String', 'html_type' => 'Select', 'label' => 'T-Shirt-Type'],
       'shirt_size' => ['data_type' => 'String', 'html_type' => 'Select', 'label' => 'T-Shirt-Size'],
       'order_count' => ['data_type' => 'Int', 'html_type' => 'Text', 'label' => 'Number of Items'],
+      'order_exported' => ['data_type' => 'Boolean', 'html_type' => 'Radio', 'label' => 'Order exported?'],
+      'order_exported_date' => ['data_type' => 'Date', 'html_type' => 'Select Date', 'label' => 'Order Exported Date'],
     ];
     $customFields = [];
 


### PR DESCRIPTION
- If action is edit and `order_exported` == '1' and empty `order_exported_date`(or empty val) - set `order_exported_date`.